### PR TITLE
readme: add mgaudet/CompilerJobs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@
 1. Телеграм-канал с новостями и полезными ссылками по тематике разработки языков и компиляторов [PLComp](https://t.me/plcomp).
 1. Телеграм-чат с обсуждением вопросов компиляции [Compiler Development](https://t.me/CompilerDev).
 1. Телеграм-канал для поиска работы в около-компиляторной области [CompilerJobs](https://t.me/compiler_jobs).
+1. Список компаний, которые занимаются компиляторами [github.com/mgaudet/CompilerJobs](https://github.com/mgaudet/CompilerJobs).


### PR DESCRIPTION
mgaudet/CompilerJobs is a community-driven effort to make a list of companies where one can find a compiler-related job.

I also think it would be nice if we can add compiler companies from Russia there. In order to do that, we need to increase their visibility for Russian-speaking folks.